### PR TITLE
Specify CodeCov upload token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,9 @@ jobs:
       - name: Upload test coverage report to Codecov
         uses: codecov/codecov-action@v4.1.0
         with:
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Run Snyk to check for vulnerabilities
         if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
Fix uploading of CodeCov code coverage reports from GitHub Actions CI.  v4 of the CodeCov GitHub action no longer supports tokenless uploading.